### PR TITLE
Refactor : 카테고리 관련 API 수정

### DIFF
--- a/src/main/java/com/zero/pennywise/component/facade/FinanceFacade.java
+++ b/src/main/java/com/zero/pennywise/component/facade/FinanceFacade.java
@@ -1,301 +1,78 @@
-//package com.zero.pennywise.component.facade;
-//
-//import com.zero.pennywise.entity.BudgetEntity;
-//import com.zero.pennywise.entity.CategoryEntity;
-//import com.zero.pennywise.entity.TransactionEntity;
-//import com.zero.pennywise.entity.UserEntity;
-//import com.zero.pennywise.exception.GlobalException;
-//import com.zero.pennywise.model.request.budget.BudgetDTO;
-//import com.zero.pennywise.model.request.budget.UpdateBudgetDTO;
-//import com.zero.pennywise.model.request.category.UpdateCategoryDTO;
-//import com.zero.pennywise.model.request.transaction.TransactionInfoDTO;
-//import com.zero.pennywise.model.response.budget.Budgets;
-//import com.zero.pennywise.model.response.page.PageResponse;
-//import com.zero.pennywise.model.response.transaction.Transactions;
-//import com.zero.pennywise.model.type.FailedResultCode;
-//import com.zero.pennywise.repository.BudgetRepository;
-//import com.zero.pennywise.repository.CategoryRepository;
-//import com.zero.pennywise.repository.TransactionRepository;
-//import com.zero.pennywise.repository.querydsl.budget.BudgetQueryRepository;
-//import com.zero.pennywise.repository.querydsl.transaction.TransactionQueryRepository;
-//import jakarta.servlet.http.HttpServletRequest;
-//import java.util.List;
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.stereotype.Component;
-//
-//@Component
-//@RequiredArgsConstructor
-//public class FinanceFacade {
-//
-//  private final CategoryRepository categoryRepository;
-//  private final TransactionRepository transactionRepository;
-//  private final BudgetRepository budgetRepository;
-//
-//  private final TransactionQueryRepository transactionQueryRepository;
-//  private final BudgetQueryRepository budgetQueryRepository;
-//
-//  // ================= Cateogry =================
-//
-//  /**
-//   * UserEntity, CategoryName과 일치하는 CategoryEntity 조회
-//   *
-//   * @param user UserEntity
-//   * @param categoryName 조회할 카테고리 명
-//   */
-//  public CategoryEntity getCategoryByUserAndCategoryName(UserEntity user, String categoryName) {
-//    return categoryRepository.findByUserAndCategoryName(user, categoryName)
-//        .orElseThrow(() -> new GlobalException(FailedResultCode.CATEGORY_NOT_FOUND));
-//  }
-//
-//
-//  /**
-//   * 카테고리 List 조회
-//   * Request Header 값으로 UserEntity 조회
-//   * UserEntity가 포함된 Category List 조회
-//   * 페이징 처리 후 PageResponse 반환
-//   *
-//   * @param request Request Header
-//   * @param page 보여줄 페이지 번호
-//   */
-//  public PageResponse<String> getUserCategoryList(HttpServletRequest request, int page) {
-//    UserEntity user = getUserByAccessToken(request);
-//
-//    List<String> categories = categoryRepository.findAllByUser(user)
-//        .map(categoryList -> categoryList.stream()
-//            .map(CategoryEntity::getCategoryName).toList())
-//        .orElseThrow(() -> new GlobalException(FailedResultCode.CATEGORY_NOT_FOUND));
-//
-//    return PageResponse.of(categories, page);
-//  }
-//
-//
-//  /**
-//   * CategoryEntity 생성
-//   * Request Header 값으로 UserEntity 조회
-//   * 카테고리 중복 여부 검증
-//   * CagegoryEntity 생성 후 반환
-//   *
-//   * @param request Request Header
-//   * @param categoryName 생성할 카테고리 명
-//   */
-//  public CategoryEntity createCategory(HttpServletRequest request, String categoryName) {
-//    UserEntity user = getUserByAccessToken(request);
-//
-//    if (categoryRepository.existsByUserAndCategoryName(user, categoryName)) {
-//      throw new GlobalException(FailedResultCode.CATEGORY_ALREADY_USED);
-//    }
-//
-//    return CategoryEntity.builder()
-//        .categoryName(categoryName)
-//        .user(user)
-//        .build();
-//  }
-//
-//
-//  /**
-//   * 카테고리 수정
-//   * Request Header 값으로 UserEntity 조회
-//   * UserEntity, CategoryName과 일치하는 CategoryEntity 조회
-//   * 수정할 카테고리명 중복 여부 검증
-//   * 수정한 CategoryEntity 반환
-//   *
-//   * @param request Request Header
-//   * @param updateCategoryDTO 수정할 카테고리 정보
-//   */
-//  public CategoryEntity updateCategory(HttpServletRequest request, UpdateCategoryDTO updateCategoryDTO) {
-//    UserEntity user = getUserByAccessToken(request);
-//
-//    CategoryEntity category = getCategoryByUserAndCategoryName(user,
-//        updateCategoryDTO.getBeforecategoryName());
-//
-//    if(categoryRepository.existsByUserAndCategoryName(user, updateCategoryDTO.getAfterCategoryName())) {
-//      throw new GlobalException(FailedResultCode.CATEGORY_ALREADY_USED);
-//    }
-//
-//    return UpdateCategoryDTO.of(category, updateCategoryDTO);
-//  }
-//
-//
-//  /**
-//   * 카테고리 저장
-//   *
-//   * @param category 저장할 CategoryEntity
-//   */
-//  public void saveCategory(CategoryEntity category) {
-//    categoryRepository.save(category);
-//  }
-//
-//
-//  /**
-//   * 카테고리 삭제
-//   * Request Header 값으로 UserEntity 조회
-//   * UserEntity, CategoryName과 일치하는 CategoryEntity 조회
-//   * CategoryEntity 삭제
-//   *
-//   * @param request Request Header
-//   * @param categoryName 삭제할 카테고리 명
-//   */
-//  public void deleteCategory(HttpServletRequest request, String categoryName) {
-//    UserEntity user = getUserByAccessToken(request);
-//
-//    CategoryEntity category = getCategoryByUserAndCategoryName(user, categoryName);
-//
-//    categoryRepository.delete(category);
-//  }
-//
-//
-//  // ================= Transaction =================
-//
-//
-//  /**
-//   * 거래 정보 List 조회
-//   * Request Header 값으로 UserEntity 조회
-//   * QueryDls을 활용하여 조건에 맞는 거래 정보 조회
-//   * 페이징 처리 후 PageResponse 반환
-//   *
-//   * @param request Request Header
-//   * @param transactionInfoDTO 조회할 거래 정보
-//   * @param page 보여줄 페이지 번호
-//   */
-//  public PageResponse<Transactions> getTransactionList(HttpServletRequest request, TransactionInfoDTO transactionInfoDTO, int page) {
-//    UserEntity user = getUserByAccessToken(request);
-//
-//    List<Transactions> transactions = transactionQueryRepository.getTransactionInfo(user, transactionInfoDTO);
-//
-//    return PageResponse.of(transactions, page);
-//  }
-//
-//
-//  /**
-//   * TransactionEntity 생성
-//   * Request Header 값으로 UserEntity 조회
-//   * UserEntity, CategoryName과 일치하는 CategoryEntity 조회
-//   * TransactionEntity 생성 후 반환
-//   *
-//   * @param request Request Header
-//   * @param transactionDTO 등록할 거래 정보
-//   */
-//  public TransactionEntity createTransaction(HttpServletRequest request, TransactionDTO transactionDTO) {
-//    UserEntity user = getUserByAccessToken(request);
-//
-//    CategoryEntity category = getCategoryByUserAndCategoryName(user, transactionDTO.getCategoryName());
-//
-//    return TransactionDTO.of(user, category, transactionDTO);
-//  }
-//
-//
-//  /**
-//   * TransactionEntity 저장
-//   *
-//   * @param transaction 저장할 TransactionEntity
-//   */
-//  public void saveTransaction(TransactionEntity transaction) {
-//    transactionRepository.save(transaction);
-//  }
-//
-//
-//  /**
-//   * TransactionEntity 삭제
-//   * transactionId 값과 일치하는 TransactionEntity 조회
-//   * 조회한 TransactionEntity 삭제
-//   *
-//   * @param transactionId 삭제할 Transaction Id값
-//   */
-//  public void deleteTransaction(HttpServletRequest request, Long transactionId) {
-//    UserEntity user = getUserByAccessToken(request);
-//
-//    TransactionEntity transaction = transactionRepository
-//        .findByUserAndTransactionId(user, transactionId)
-//        .orElseThrow(() -> new GlobalException(FailedResultCode.TRANSACTION_NOT_FOUND));
-//
-//    transactionRepository.delete(transaction);
-//  }
-//
-//
-//  // ================= Budget =================
-//
-//
-//  /**
-//   * 예산 List 조회
-//   * Request Header 값으로 UserEntity 조회
-//   * UserEntity, CategoryName과 일치하는 BudgetList 조회
-//   * 페이징 처리 후 PageResponse 반환
-//   *
-//   * @param request Request Header
-//   * @param categoryName 조회할 예산의 카테고리 명
-//   * @param page 보여줄 페이지 번호
-//   */
-//  public PageResponse<Budgets> getBudgetList(HttpServletRequest request, String categoryName, int page) {
-//    UserEntity user = getUserByAccessToken(request);
-//
-//    List<Budgets> budgets = budgetQueryRepository.getBudgetList(user, categoryName);
-//
-//    return PageResponse.of(budgets, page);
-//  }
-//
-//
-//  /**
-//   * BudgetEntity 생성
-//   * Request Header 값으로 UserEntity 조회
-//   * UserEntity, CategoryName과 일치하는 CategoryEntity 조회
-//   * 조회한 정보 및 입력한 정보를 활용하여 BudgetEntity 생성 후 반환
-//   *
-//   * @param request Request Header
-//   * @param budgetDTO 등록할 예산 정보
-//   */
-//  public BudgetEntity createBudget(HttpServletRequest request, BudgetDTO budgetDTO) {
-//    UserEntity user = getUserByAccessToken(request);
-//
-//    CategoryEntity category = getCategoryByUserAndCategoryName(user, budgetDTO.getCategoryName());
-//
-//    if (budgetRepository.existsByUserAndCategory(user, category)) {
-//      throw new GlobalException(FailedResultCode.BUDGET_ALREADY_USED);
-//    }
-//
-//    return BudgetDTO.of(user, category, budgetDTO);
-//  }
-//
-//  /**
-//   * BudgetEntity 저장
-//   *
-//   * @param budget 저장할 BudgetEntity
-//   */
-//  public void saveBudget(BudgetEntity budget) {
-//    budgetRepository.save(budget);
-//  }
-//
-//
-//  /**
-//   * BudgetEntity 수정
-//   * Request Header 값으로 UserEntity 조회
-//   * UserEntity, CategoryName과 일치하는 CategoryEntity 조회
-//   * 조회한 정보 및 입력한 정보를 활용하여 BudgetEntity 수정 후 반환
-//   *
-//   * @param request Request Header
-//   * @param updateBudgetDTO 수정할 예산 정보
-//   */
-//  public BudgetEntity updateBudget(HttpServletRequest request, UpdateBudgetDTO updateBudgetDTO) {
-//    UserEntity user = getUserByAccessToken(request);
-//
-//    CategoryEntity category = getCategoryByUserAndCategoryName(user, updateBudgetDTO.getCategoryName());
-//
-//    return UpdateBudgetDTO.of(user, category, updateBudgetDTO);
-//  }
-//
-//  /**
-//   * BudgetEntity 삭제
-//   * budgetId 값과 일치하는 BudgetEntity 조회
-//   * 조회한 BudgetEntity 삭제
-//   *
-//   * @param budgetId 삭제할 BudgetEntity Id 값
-//   */
-//  public void deleteBudget(HttpServletRequest request, Long budgetId) {
-//    UserEntity user = getUserByAccessToken(request);
-//
-//    BudgetEntity budget = budgetRepository.findByBudgetIdAndUser(budgetId, user)
-//        .orElseThrow(() -> new GlobalException(FailedResultCode.BUDGET_NOT_FOUND));
-//
-//    budgetRepository.delete(budget);
-//  }
-//
-//}
+package com.zero.pennywise.component.facade;
+
+import com.zero.pennywise.entity.CategoryEntity;
+import com.zero.pennywise.entity.UserEntity;
+import com.zero.pennywise.exception.GlobalException;
+import com.zero.pennywise.model.type.FailedResultCode;
+import com.zero.pennywise.repository.CategoryRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * 재무 관련 작업을 처리하는 퍼사드 컴포넌트.
+ * 카테고리 관리를 위한 비즈니스 로직을 캡슐화합니다.
+ */
+@Component
+@RequiredArgsConstructor
+public class FinanceFacade {
+
+  // 카테고리 데이터 접근을 위한 리포지토리
+  private final CategoryRepository categoryRepository;
+
+  /**
+   * 특정 사용자의 모든 카테고리 목록을 조회합니다.
+   *
+   * @param user 카테고리를 조회할 사용자 엔티티
+   * @return 사용자의 카테고리 이름 목록 (존재하지 않을 경우 빈 리스트)
+   */
+  public List<String> getCategoryList(UserEntity user) {
+    return categoryRepository.findAllByUser(user)
+        .map(categoryList -> categoryList.stream()
+            .map(CategoryEntity::getCategoryName)
+            .collect(Collectors.toList()))
+        .orElse(new ArrayList<>());
+  }
+
+  /**
+   * 카테고리 생성 전 중복 여부를 검증합니다.
+   *
+   * @param user 카테고리를 생성하려는 사용자 엔티티
+   * @param categoryName 검증할 카테고리 이름
+   * @throws GlobalException 이미 존재하는 카테고리일 경우 예외 발생
+   */
+  public void validateCategory(UserEntity user, String categoryName) {
+    // 동일한 카테고리명이 이미 존재하는지 확인
+    if(categoryRepository.existsByUserAndCategoryName(user, categoryName)) {
+      throw new GlobalException(FailedResultCode.CATEGORY_ALREADY_USED);
+    }
+  }
+
+  /**
+   * 새로운 카테고리를 생성하고 저장합니다.
+   *
+   * @param user 카테고리를 생성하는 사용자 엔티티
+   * @param categoryName 생성할 카테고리 이름
+   */
+  public void createAndSaveCategory(UserEntity user, String categoryName) {
+    // 새로운 카테고리 엔티티 생성 및 저장
+    categoryRepository.save(
+        CategoryEntity.builder()
+            .user(user)
+            .categoryName(categoryName)
+            .build());
+  }
+
+  /**
+   * 특정 사용자의 카테고리를 삭제합니다.
+   *
+   * @param user 카테고리를 삭제하는 사용자 엔티티
+   * @param categoryName 삭제할 카테고리 이름
+   */
+  public void deleteCategory(UserEntity user, String categoryName) {
+    // 사용자와 카테고리명으로 카테고리 삭제
+    categoryRepository.deleteByUserAndCategoryName(user, categoryName);
+  }
+}

--- a/src/main/java/com/zero/pennywise/controller/CategoryController.java
+++ b/src/main/java/com/zero/pennywise/controller/CategoryController.java
@@ -1,68 +1,70 @@
-//package com.zero.pennywise.controller;
-//
-//import com.zero.pennywise.model.request.category.UpdateCategoryDTO;
-//import com.zero.pennywise.model.response.ResultResponse;
-//import com.zero.pennywise.service.CategoryService;
-//import jakarta.servlet.http.HttpServletRequest;
-//import jakarta.validation.Valid;
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.http.ResponseEntity;
-//import org.springframework.web.bind.annotation.DeleteMapping;
-//import org.springframework.web.bind.annotation.GetMapping;
-//import org.springframework.web.bind.annotation.PostMapping;
-//import org.springframework.web.bind.annotation.PutMapping;
-//import org.springframework.web.bind.annotation.RequestBody;
-//import org.springframework.web.bind.annotation.RequestMapping;
-//import org.springframework.web.bind.annotation.RequestParam;
-//import org.springframework.web.bind.annotation.RestController;
-//
-//@RestController
-//@RequiredArgsConstructor
-//@RequestMapping("/api/v1/categories")
-//public class CategoryController {
-//
-//  private final CategoryService categoryService;
-//
-//  // 카테고리 목록 출력
-//  @GetMapping
-//  public ResponseEntity<ResultResponse> category(
-//      @RequestParam("page") int page,
-//      HttpServletRequest request) {
-//
-//    ResultResponse resultResponse = categoryService.getCategoryList(page, request);
-//    return new ResponseEntity<>(resultResponse, resultResponse.getStatus());
-//  }
-//
-//
-//  // 카테고리 생성
-//  @PostMapping
-//  public ResponseEntity<ResultResponse> createCategory(
-//      @RequestParam("categoryName") String categoryName,
-//      HttpServletRequest request) {
-//
-//    ResultResponse resultResponse = categoryService.createCategory(categoryName, request);
-//    return new ResponseEntity<>(resultResponse, resultResponse.getStatus());
-//  }
-//
-//  // 카테고리 수정
-//  @PutMapping
-//  public ResponseEntity<ResultResponse> updateCategory(
-//      @RequestBody @Valid UpdateCategoryDTO updateCategoryDTO,
-//      HttpServletRequest request) {
-//
-//    ResultResponse resultResponse = categoryService.updateCategory(updateCategoryDTO, request);
-//    return new ResponseEntity<>(resultResponse, resultResponse.getStatus());
-//  }
-//
-//
-//  // 카테고리 삭제
-//  @DeleteMapping
-//  public ResponseEntity<ResultResponse> deleteCategory(
-//      @RequestParam("categoryName") String categoryName,
-//      HttpServletRequest request) {
-//
-//
-//    ResultResponse resultResponse = categoryService.deleteCategory(categoryName, request);
-//    return new ResponseEntity<>(resultResponse, resultResponse.getStatus());
-//  }
-//}
+package com.zero.pennywise.controller;
+
+import com.zero.pennywise.model.response.ResultResponse;
+import com.zero.pennywise.service.CategoryService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 카테고리 관련 작업을 처리하는 REST 컨트롤러.
+ * 카테고리 조회, 생성, 삭제 엔드포인트를 제공합니다.
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/category")
+public class CategoryController {
+
+  // 카테고리 관련 비즈니스 로직을 처리하는 서비스 계층
+  private final CategoryService categoryService;
+
+  /**
+   * 현재 사용자의 카테고리 목록을 조회합니다.
+   *
+   * @param request 사용자 인증 정보를 포함하는 HTTP 서블릿 요청
+   * @return 카테고리 목록과 적절한 HTTP 상태를 포함한 ResponseEntity
+   */
+  @GetMapping
+  public ResponseEntity<ResultResponse> getCategoryList(HttpServletRequest request) {
+    ResultResponse response = categoryService.getCategoryList(request);
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+
+  /**
+   * 현재 사용자를 위한 새로운 카테고리를 생성합니다.
+   *
+   * @param request 사용자 인증 정보를 포함하는 HTTP 서블릿 요청
+   * @param categoryName 생성할 카테고리의 이름
+   * @return 카테고리 생성 결과와 적절한 HTTP 상태를 포함한 ResponseEntity
+   */
+  @PostMapping
+  public ResponseEntity<ResultResponse> createCategory(
+      HttpServletRequest request,
+      @RequestParam("categoryName") String categoryName) {
+
+    ResultResponse resultResponse = categoryService.createCategory(request, categoryName);
+    return new ResponseEntity<>(resultResponse, resultResponse.getStatus());
+  }
+
+  /**
+   * 현재 사용자의 기존 카테고리를 삭제합니다.
+   *
+   * @param request 사용자 인증 정보를 포함하는 HTTP 서블릿 요청
+   * @param categoryName 삭제할 카테고리의 이름
+   * @return 카테고리 삭제 결과와 적절한 HTTP 상태를 포함한 ResponseEntity
+   */
+  @DeleteMapping
+  public ResponseEntity<ResultResponse> deleteCategory(
+      HttpServletRequest request,
+      @RequestParam("categoryName") String categoryName) {
+
+    ResultResponse resultResponse = categoryService.deleteCategory(request, categoryName);
+    return new ResponseEntity<>(resultResponse, resultResponse.getStatus());
+  }
+}

--- a/src/main/java/com/zero/pennywise/repository/CategoryRepository.java
+++ b/src/main/java/com/zero/pennywise/repository/CategoryRepository.java
@@ -13,11 +13,10 @@ public interface CategoryRepository extends JpaRepository<CategoryEntity, Long> 
   // 사용자의 모든 카테고리 조회
   Optional<List<CategoryEntity>> findAllByUser(UserEntity user);
 
-  // 카테고리 중복 여부 검증
   boolean existsByUserAndCategoryName(UserEntity user, String categoryName);
 
-  Optional<CategoryEntity> findByUserAndCategoryName(UserEntity user, String categoryName);
+  void deleteByUserAndCategoryName(UserEntity user, String categoryName);
 
-  void deleteAllByUser(UserEntity user);
+  // 카테고리 중복 여부 검증
 
 }

--- a/src/main/java/com/zero/pennywise/service/CategoryService.java
+++ b/src/main/java/com/zero/pennywise/service/CategoryService.java
@@ -1,16 +1,13 @@
-//package com.zero.pennywise.service;
-//
-//import com.zero.pennywise.model.request.category.UpdateCategoryDTO;
-//import com.zero.pennywise.model.response.ResultResponse;
-//import jakarta.servlet.http.HttpServletRequest;
-//
-//public interface CategoryService {
-//
-//  ResultResponse getCategoryList(int page, HttpServletRequest request);
-//
-//  ResultResponse createCategory(String categoryName, HttpServletRequest request);
-//
-//  ResultResponse updateCategory(UpdateCategoryDTO updateCategoryDTO, HttpServletRequest request);
-//
-//  ResultResponse deleteCategory(String categoryName, HttpServletRequest request);
-//}
+package com.zero.pennywise.service;
+
+import com.zero.pennywise.model.response.ResultResponse;
+import jakarta.servlet.http.HttpServletRequest;
+
+public interface CategoryService {
+
+  ResultResponse getCategoryList(HttpServletRequest request);
+
+  ResultResponse createCategory(HttpServletRequest request, String categoryName);
+
+  ResultResponse deleteCategory(HttpServletRequest request, String categoryName);
+}

--- a/src/main/java/com/zero/pennywise/service/impl/CategoryServiceImpl.java
+++ b/src/main/java/com/zero/pennywise/service/impl/CategoryServiceImpl.java
@@ -1,60 +1,73 @@
-//package com.zero.pennywise.service.impl;
-//
-//import com.zero.pennywise.component.facade.UserFacade;
-//import com.zero.pennywise.entity.CategoryEntity;
-//import com.zero.pennywise.model.request.category.UpdateCategoryDTO;
-//import com.zero.pennywise.model.response.ResultResponse;
-//import com.zero.pennywise.model.response.page.PageResponse;
-//import com.zero.pennywise.model.type.SuccessResultCode;
-//import com.zero.pennywise.service.CategoryService;
-//import jakarta.servlet.http.HttpServletRequest;
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.stereotype.Service;
-//import org.springframework.transaction.annotation.Transactional;
-//
-//@Service
-//@RequiredArgsConstructor
-//public class CategoryServiceImpl implements CategoryService {
-//
-//  private final UserFacade userFacade;
-//
-//  // 카테고리 목록
-//  @Override
-//  public ResultResponse getCategoryList(int page, HttpServletRequest request) {
-//    PageResponse<String> response = userFacade.getUserCategoryList(request, page);
-//
-//    return new ResultResponse(SuccessResultCode.SUCCESS_GET_CATEGORY_LIST, response);
-//  }
-//
-//
-//  // 카테고리 생성
-//  @Override
-//  public ResultResponse createCategory(String categoryName, HttpServletRequest request) {
-//    CategoryEntity category = userFacade.createCategory(request, categoryName);
-//
-//    userFacade.saveCategory(category);
-//
-//    return ResultResponse.of(SuccessResultCode.SUCCESS_CREATE_CATEGORY);
-//  }
-//
-//  // 카테고리 수정
-//  @Override
-//  @Transactional
-//  public ResultResponse updateCategory(UpdateCategoryDTO updateCategoryDTO, HttpServletRequest request) {
-//    CategoryEntity category = userFacade.updateCategory(request, updateCategoryDTO);
-//
-//    userFacade.saveCategory(category);
-//
-//    return ResultResponse.of(SuccessResultCode.SUCCESS_UPDATE_CATEGORY);
-//  }
-//
-//
-//  // 카테고리 삭제
-//  @Override
-//  @Transactional
-//  public ResultResponse deleteCategory(String categoryName, HttpServletRequest request) {
-//    userFacade.deleteCategory(request, categoryName);
-//
-//    return ResultResponse.of(SuccessResultCode.SUCCESS_DELETE_CATEGORY);
-//  }
-//}
+package com.zero.pennywise.service.impl;
+
+import com.zero.pennywise.component.facade.FinanceFacade;
+import com.zero.pennywise.component.facade.UserFacade;
+import com.zero.pennywise.entity.UserEntity;
+import com.zero.pennywise.model.response.ResultResponse;
+import com.zero.pennywise.model.type.SuccessResultCode;
+import com.zero.pennywise.service.CategoryService;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * 카테고리 서비스의 구현체.
+ * 사용자 인증과 재무 관련 작업을 처리하는 퍼사드를 활용하여
+ * 카테고리 관련 비즈니스 로직을 수행합니다.
+ */
+@Service
+@RequiredArgsConstructor
+public class CategoryServiceImpl implements CategoryService {
+
+  private final UserFacade userFacade;
+  private final FinanceFacade financeFacade;
+
+  /**
+   * 현재 사용자의 카테고리 목록을 조회합니다.
+   *
+   * @param request 사용자 인증 정보를 포함하는 HTTP 서블릿 요청
+   * @return 사용자의 카테고리 목록을 포함한 ResultResponse
+   */
+  @Override
+  public ResultResponse getCategoryList(HttpServletRequest request) {
+    UserEntity user = userFacade.getUserByAccessToken(request);
+
+    List<String> response = financeFacade.getCategoryList(user);
+
+    return new ResultResponse(SuccessResultCode.SUCCESS_GET_CATEGORY_LIST, response);
+  }
+
+  /**
+   * 새로운 카테고리를 생성합니다.
+   *
+   * @param request 사용자 인증 정보를 포함하는 HTTP 서블릿 요청
+   * @param categoryName 생성할 카테고리의 이름
+   * @return 카테고리 생성 결과를 포함한 ResultResponse
+   */
+  @Override
+  public ResultResponse createCategory(HttpServletRequest request, String categoryName) {
+    UserEntity user = userFacade.getUserByAccessToken(request);
+
+    financeFacade.validateCategory(user, categoryName);
+    financeFacade.createAndSaveCategory(user, categoryName);
+
+    return ResultResponse.of(SuccessResultCode.SUCCESS_CREATE_CATEGORY);
+  }
+
+  /**
+   * 기존 카테고리를 삭제합니다.
+   *
+   * @param request 사용자 인증 정보를 포함하는 HTTP 서블릿 요청
+   * @param categoryName 삭제할 카테고리의 이름
+   * @return 카테고리 삭제 결과를 포함한 ResultResponse
+   */
+  @Override
+  public ResultResponse deleteCategory(HttpServletRequest request, String categoryName) {
+    UserEntity user = userFacade.getUserByAccessToken(request);
+
+    financeFacade.deleteCategory(user, categoryName);
+
+    return ResultResponse.of(SuccessResultCode.SUCCESS_DELETE_CATEGORY);
+  }
+}


### PR DESCRIPTION
## 변경사항

## FinanceFacade
- 카테고리 관련 메서드 리팩토링
    - `getCategoryList()`: 사용자의 카테고리 이름 목록 반환 로직 단순화
    - `validateCategory()`: 카테고리 중복 검사 메서드 추가
    - `createAndSaveCategory()`: 카테고리 생성과 저장을 단일 메서드로 통합
    - `deleteCategory()`: 삭제 로직 간소화
- HTTP 서블릿 요청 관련 메서드 제거
- 불필요한 중복 코드 제거

## CategoryController
- URL 매핑 변경: `/api/v1/categories` → `/api/v1/category`
- 메서드 시그니처 및 파라미터 순서 최적화
    - `getCategoryList()`: 페이지 파라미터 제거
- 메서드별 상세 주석 추가
- 응답 처리 로직 일관성 개선

## CategoryRepository
- 메서드 정리
    - `findByUserAndCategoryName()` 메서드 제거
    - `deleteByUserAndCategoryName()` 메서드 추가
- 불필요한 메서드 제거
- 카테고리 관련 기본 데이터 조회 및 삭제 메서드 유지

## CategoryService
- 인터페이스 메서드 단순화
    - 페이징 관련 메서드 제거
    - 메서드 파라미터 순서 및 구조 최적화
- 메서드 시그니처 일관성 개선

## CategoryServiceImpl
- 의존성 주입 개선
    - `UserFacade`와 `FinanceFacade` 동시 사용
- 메서드 구현 리팩토링
    - `getCategoryList()`: 페이징 처리 제거, 단순 목록 조회로 변경
    - `createCategory()`: 카테고리 검증 및 생성 로직 통합
    - `deleteCategory()`: 삭제 로직 최적화
- 메서드별 상세 주석 추가
- 코드 가독성 및 일관성 개선


이번 리팩토링은 전반적인 코드 품질 개선과 유지보수성 향상에 중점을 두고 있습니다.